### PR TITLE
作成済みの何故何故分析を編集する機能を実装しました

### DIFF
--- a/whywhyanalysisApp/AnalysisListCustumCell.xib
+++ b/whywhyanalysisApp/AnalysisListCustumCell.xib
@@ -14,14 +14,21 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="問題ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2NN-sQ-tG0" customClass="anaysisListCustomCell" customModule="whywhyanalysisApp" customModuleProvider="target">
-                    <rect key="frame" x="66" y="49" width="219" height="21"/>
+                    <rect key="frame" x="16" y="98" width="219" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="対策ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yc4-at-u87">
-                    <rect key="frame" x="66" y="20" width="219" height="21"/>
+                    <rect key="frame" x="16" y="69" width="219" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AAh-2a-ieh">
+                    <rect key="frame" x="210" y="30" width="89" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
@@ -33,6 +40,7 @@
             <connections>
                 <outlet property="measuresLabel" destination="Yc4-at-u87" id="WJq-kK-RBS"/>
                 <outlet property="problemLabel" destination="2NN-sQ-tG0" id="EIO-0o-LUO"/>
+                <outlet property="statusLabel" destination="AAh-2a-ieh" id="7dK-9K-ED9"/>
             </connections>
             <point key="canvasLocation" x="-258.75" y="66.549295774647888"/>
         </view>

--- a/whywhyanalysisApp/Base.lproj/Main.storyboard
+++ b/whywhyanalysisApp/Base.lproj/Main.storyboard
@@ -110,13 +110,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="以下の内容で登録します。" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Umt-pK-rzv">
-                                <rect key="frame" x="83.5" y="88" width="208" height="21"/>
+                                <rect key="frame" x="83.5" y="39" width="208" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e8y-gs-tY0">
-                                <rect key="frame" x="150" y="146" width="75" height="30"/>
+                                <rect key="frame" x="167.5" y="82" width="40" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="A9i-1w-hIf"/>
                                     <constraint firstAttribute="height" constant="30" id="boA-9u-0B3"/>
@@ -130,7 +130,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題内容" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btg-5T-evG">
-                                <rect key="frame" x="24" y="213" width="70" height="21"/>
+                                <rect key="frame" x="24" y="135" width="70" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -140,7 +140,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1tG-E1-bXU">
-                                <rect key="frame" x="150" y="287" width="75" height="30"/>
+                                <rect key="frame" x="167.5" y="193" width="40" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="8dF-j4-WcC"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="bzR-GB-zzd"/>
@@ -150,13 +150,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題内容" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mcn-8Z-duW">
-                                <rect key="frame" x="24" y="358" width="70" height="21"/>
+                                <rect key="frame" x="24" y="242" width="70" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" restorationIdentifier="confirmButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="89t-s4-tNp">
-                                <rect key="frame" x="157.5" y="507" width="60" height="40"/>
+                                <rect key="frame" x="157.5" y="571" width="60" height="40"/>
                                 <color key="backgroundColor" red="0.46240979430000001" green="0.65963476899999995" blue="0.81570786240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="8U1-ug-04c"/>
@@ -169,34 +169,49 @@
                                     <action selector="registAnalysis:" destination="URt-nh-7uV" eventType="touchUpInside" id="Fg0-Zf-bcn"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="進捗" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jjv-79-Td9">
+                                <rect key="frame" x="98" y="310" width="35" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dj1-LE-BKz">
+                                <rect key="frame" x="186" y="286" width="137" height="65"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="137" id="c0j-8S-zcy"/>
+                                    <constraint firstAttribute="height" constant="65" id="iD2-7j-bKf"/>
+                                </constraints>
+                            </pickerView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstAttribute="trailingMargin" secondItem="K19-CC-DLi" secondAttribute="trailing" constant="27" id="2IE-A0-hbk"/>
-                            <constraint firstItem="btg-5T-evG" firstAttribute="top" secondItem="Umt-pK-rzv" secondAttribute="bottom" constant="104" id="2aV-wL-nwd"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="leading" secondItem="kNt-9k-Rcr" secondAttribute="leading" id="5hF-hD-1Ok"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="btg-5T-evG" secondAttribute="trailing" id="6rI-XZ-eC8"/>
-                            <constraint firstItem="btg-5T-evG" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="24" id="A8j-nR-ZMF"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="top" secondItem="btg-5T-evG" secondAttribute="bottom" constant="-49" id="Fda-q1-fKw"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="trailing" secondItem="kNt-9k-Rcr" secondAttribute="trailing" id="GlH-ox-sn7"/>
-                            <constraint firstItem="1tG-E1-bXU" firstAttribute="leading" secondItem="e8y-gs-tY0" secondAttribute="leading" id="K64-Hg-oH5"/>
-                            <constraint firstItem="kNt-9k-Rcr" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="501" id="KEH-c2-8yA"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="185" id="MDR-bS-KR6"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" secondItem="e8y-gs-tY0" secondAttribute="trailing" constant="150" id="OdC-8U-Lmo"/>
-                            <constraint firstItem="1tG-E1-bXU" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="287" id="Pb5-2O-Yd6"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="bottom" secondItem="btg-5T-evG" secondAttribute="bottom" constant="-49" id="SOU-w2-v4p"/>
-                            <constraint firstAttribute="bottom" secondItem="mcn-8Z-duW" secondAttribute="bottom" constant="288" id="VoG-0J-qH0"/>
-                            <constraint firstItem="mcn-8Z-duW" firstAttribute="leading" secondItem="btg-5T-evG" secondAttribute="leading" id="WZR-ga-49m"/>
-                            <constraint firstItem="e8y-gs-tY0" firstAttribute="top" secondItem="Umt-pK-rzv" secondAttribute="bottom" constant="37" id="giB-sv-ErB"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mcn-8Z-duW" secondAttribute="trailing" symbolic="YES" id="h7i-XF-bgv"/>
-                            <constraint firstItem="K19-CC-DLi" firstAttribute="leading" secondItem="IJH-zM-e91" secondAttribute="leadingMargin" constant="35" id="i9C-wn-pgc"/>
-                            <constraint firstItem="1tG-E1-bXU" firstAttribute="trailing" secondItem="e8y-gs-tY0" secondAttribute="trailing" id="ihd-8y-QaK"/>
-                            <constraint firstItem="e8y-gs-tY0" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="150" id="j61-5V-bMP"/>
-                            <constraint firstItem="89t-s4-tNp" firstAttribute="centerX" secondItem="IJH-zM-e91" secondAttribute="centerX" id="l3b-KB-fvA"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="bottom" secondItem="89t-s4-tNp" secondAttribute="bottom" constant="120" id="lRo-Wj-1t7"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="bottom" secondItem="kNt-9k-Rcr" secondAttribute="bottom" constant="160" id="nO6-Ie-6iW"/>
-                            <constraint firstItem="e8y-gs-tY0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="oAB-IA-Fqg" secondAttribute="leading" id="uE0-w2-c7j"/>
-                            <constraint firstItem="Umt-pK-rzv" firstAttribute="centerX" secondItem="IJH-zM-e91" secondAttribute="centerX" id="upM-IE-rDN"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="top" secondItem="Umt-pK-rzv" secondAttribute="bottom" constant="22" id="1xz-YD-bq5"/>
+                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="btg-5T-evG" secondAttribute="trailing" symbolic="YES" id="4wh-D9-zhH"/>
+                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="bottom" secondItem="89t-s4-tNp" secondAttribute="bottom" constant="56" id="5Dn-sT-Npt"/>
+                            <constraint firstItem="jjv-79-Td9" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="310" id="6Ff-Ir-Itc"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="centerX" secondItem="IJH-zM-e91" secondAttribute="centerX" id="6Lm-E4-OjJ"/>
+                            <constraint firstItem="dj1-LE-BKz" firstAttribute="top" secondItem="1tG-E1-bXU" secondAttribute="bottom" constant="63" id="76j-qg-S08"/>
+                            <constraint firstItem="K19-CC-DLi" firstAttribute="leading" secondItem="IJH-zM-e91" secondAttribute="leadingMargin" constant="35" id="BqK-NO-XnE"/>
+                            <constraint firstItem="jjv-79-Td9" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="98" id="Et6-kF-DiV"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="centerX" secondItem="Umt-pK-rzv" secondAttribute="centerX" id="IFa-jj-ijQ"/>
+                            <constraint firstItem="kNt-9k-Rcr" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="501" id="Jqd-ve-eAb"/>
+                            <constraint firstItem="K19-CC-DLi" firstAttribute="top" secondItem="e8y-gs-tY0" secondAttribute="bottom" constant="73" id="KIl-2T-TPi"/>
+                            <constraint firstItem="1tG-E1-bXU" firstAttribute="top" secondItem="K19-CC-DLi" secondAttribute="bottom" constant="8" symbolic="YES" id="LaR-g8-YtY"/>
+                            <constraint firstItem="mcn-8Z-duW" firstAttribute="top" secondItem="K19-CC-DLi" secondAttribute="bottom" constant="57" id="M7h-qR-uzd"/>
+                            <constraint firstItem="btg-5T-evG" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="24" id="MAY-uJ-Ts6"/>
+                            <constraint firstItem="K19-CC-DLi" firstAttribute="top" secondItem="btg-5T-evG" secondAttribute="bottom" constant="29" id="MDg-bb-9Om"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="top" secondItem="IJH-zM-e91" secondAttribute="top" constant="82" id="SMA-rs-kBn"/>
+                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mcn-8Z-duW" secondAttribute="trailing" symbolic="YES" id="anN-ul-wle"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="centerX" secondItem="89t-s4-tNp" secondAttribute="centerX" id="bWQ-pB-aTV"/>
+                            <constraint firstAttribute="bottom" secondItem="K19-CC-DLi" secondAttribute="bottom" constant="482" id="cjA-ot-03I"/>
+                            <constraint firstItem="btg-5T-evG" firstAttribute="leading" secondItem="mcn-8Z-duW" secondAttribute="leading" id="gvM-O9-S8k"/>
+                            <constraint firstItem="e8y-gs-tY0" firstAttribute="centerX" secondItem="1tG-E1-bXU" secondAttribute="centerX" id="k1u-OP-6rJ"/>
+                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" secondItem="dj1-LE-BKz" secondAttribute="trailing" constant="52" id="noc-bP-tIf"/>
+                            <constraint firstItem="K19-CC-DLi" firstAttribute="trailing" secondItem="kNt-9k-Rcr" secondAttribute="trailing" id="qvB-lh-b50"/>
+                            <constraint firstItem="89t-s4-tNp" firstAttribute="top" secondItem="kNt-9k-Rcr" secondAttribute="bottom" constant="64" id="rol-UT-ieB"/>
+                            <constraint firstItem="K19-CC-DLi" firstAttribute="leading" secondItem="kNt-9k-Rcr" secondAttribute="leading" id="wjK-zf-hcM"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="K19-CC-DLi" secondAttribute="trailing" constant="27" id="wkr-5e-MiP"/>
+                            <constraint firstItem="dj1-LE-BKz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jjv-79-Td9" secondAttribute="trailing" constant="8" symbolic="YES" id="zJ2-uU-4uI"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="oAB-IA-Fqg"/>
                     </view>
@@ -204,11 +219,12 @@
                     <connections>
                         <outlet property="measuresLabel" destination="mcn-8Z-duW" id="0Zx-MG-Li7"/>
                         <outlet property="problemLabel" destination="btg-5T-evG" id="N40-sY-DRg"/>
+                        <outlet property="statusPickerView" destination="dj1-LE-BKz" id="sTX-y1-meN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Xfc-Hr-GBF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1868" y="806"/>
+            <point key="canvasLocation" x="1868" y="805.54722638680664"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="vLV-Kq-kq8">

--- a/whywhyanalysisApp/Controller/EditAnalysisViewController.swift
+++ b/whywhyanalysisApp/Controller/EditAnalysisViewController.swift
@@ -51,6 +51,7 @@ class EditAnalysisViewController: UIViewController {
             var threeWhy = ""
             var fourWhy = ""
             var fiveWhy = ""
+            let status = "実施中"
             
             if(ValidateUtility.isTextNotEmplyCheck(optinalText:analysisView.twoWhyTextField.text)) {
                 twoWhy = analysisView.twoWhyTextField.text!
@@ -65,9 +66,18 @@ class EditAnalysisViewController: UIViewController {
             if(ValidateUtility.isTextNotEmplyCheck(optinalText: analysisView.fiveWhyTextField.text)) {
                 fiveWhy = analysisView.fiveWhyTextField.text!
             }
-            let whywhyAnalysis = WhywhyAnalysis(problem: analysisView.problemTextField.text!, measures: analysisView.measuresTextField.text!, oneWhy: analysisView.oneWhyTextFiled.text!, twoWhy: twoWhy, threeWhy: threeWhy, fourWhy: fourWhy, fiveWhy: fiveWhy)
+   
+            // 修正後の内容で初期化
+            let editWhywhyAnalysis = WhywhyAnalysis(problem: analysisView.problemTextField.text!, measures: analysisView.measuresTextField.text!, oneWhy: analysisView.oneWhyTextFiled.text!, twoWhy: twoWhy, threeWhy: threeWhy, fourWhy: fourWhy, fiveWhy: fiveWhy, status: status)
+            
+            // 画面遷移
             let nextViewController = R.storyboard.main.resistAnalysis()
-            nextViewController?.whywhyAnalysis = whywhyAnalysis
+            nextViewController?.whywhyAnalysis = editWhywhyAnalysis
+            
+            if(mode == "編集") {
+                nextViewController?.whywhyAnalysis.whywhyAnalysisNo = whywhyAnalysis.whywhyAnalysisNo
+                nextViewController?.whywhyAnalysis.status = whywhyAnalysis.status
+            } 
             nextViewController?.mode = analysisView.mode
             if nextViewController != nil {
                 navigationController?.pushViewController(nextViewController!, animated: true)

--- a/whywhyanalysisApp/Controller/HomeViewController.swift
+++ b/whywhyanalysisApp/Controller/HomeViewController.swift
@@ -82,6 +82,11 @@ class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDe
             // TODO: 後ほどエラー処理を実装
             cell.problemLabel.text = "取得失敗したよ"
         }
+        
+        if(cell.statusLabel.text != nil) {
+            cell.statusLabel.text = whywhyAnalysisList[row].status!
+        }
+        
         return cell
     }
     

--- a/whywhyanalysisApp/Controller/RegistAnalysisViewController.swift
+++ b/whywhyanalysisApp/Controller/RegistAnalysisViewController.swift
@@ -37,13 +37,7 @@ class RegistAnalysisViewController: UIViewController,  UIPickerViewDelegate, UIP
             status = statusList[0]
             statusNum = 0
         } else if(mode == "編集") {
-            status = whywhyAnalysis.status
-            for s in statusList {
-                if(s == status) {
-                    break
-                }
-                statusNum += 1
-            }
+            statusNum = statusList.firstIndex(of: whywhyAnalysis.status)!
         }
         
         self.statusPickerView.selectRow(statusNum, inComponent: 0, animated: false)

--- a/whywhyanalysisApp/Controller/RegistAnalysisViewController.swift
+++ b/whywhyanalysisApp/Controller/RegistAnalysisViewController.swift
@@ -8,32 +8,79 @@
 
 import UIKit
 
-class RegistAnalysisViewController: UIViewController {
+class RegistAnalysisViewController: UIViewController,  UIPickerViewDelegate, UIPickerViewDataSource {
     
     @IBOutlet weak var problemLabel: UILabel!
     
     @IBOutlet weak var measuresLabel: UILabel!
-
+    
+    @IBOutlet weak var statusPickerView: UIPickerView!
+    
+    let statusList = ["実施中", "達成", "未達成"]
+    
     var whywhyAnalysis: WhywhyAnalysis!
     
     var mode = ""
-
+    
+    var status = ""
+    
+    var statusNum = 0
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        statusPickerView.dataSource = self
+        statusPickerView.delegate = self
+        
         problemLabel.text = whywhyAnalysis.problem
         measuresLabel.text = whywhyAnalysis.measures
+        if(mode == "新規作成") {
+            status = statusList[0]
+            statusNum = 0
+        } else if(mode == "編集") {
+            status = whywhyAnalysis.status
+            for s in statusList {
+                if(s == status) {
+                    break
+                }
+                statusNum += 1
+            }
+        }
+        
+        self.statusPickerView.selectRow(statusNum, inComponent: 0, animated: false)
     }
-
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return statusList.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView,
+                    titleForRow row: Int,
+                    forComponent component: Int) -> String? {
+        return statusList[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView,
+                    didSelectRow row: Int,
+                    inComponent component: Int) {
+        status = statusList[row]
+        
+    }
+    
     // 何故何故分析を登録
     @IBAction func registAnalysis(_ sender: Any) {
+        whywhyAnalysis.status = status
+        
         let data = DataStorage()
         switch mode {
         case "新規作成":
             data.createWhyAnalyticsData(whywhyAnalysis)
             break
         case "編集":
-            // TODO: 後ほど編集する処理を実装
-            print("編集する")
+            data.editWhyAnalyticsData(whywhyAnalysis)
             break
         default:
             // TODO: 後ほどエラー処理またはアラート処理を実装

--- a/whywhyanalysisApp/Model/DataStorage.swift
+++ b/whywhyanalysisApp/Model/DataStorage.swift
@@ -25,8 +25,12 @@ class DataStorage {
     // 新規何故何故分析を追加
     func createWhyAnalyticsData(_ analysis:WhywhyAnalysis) {
         // WhywhyAnalysisNoの最大値
-        var maxWhywhyAnalysisNo: Int { return try! Realm().objects(WhywhyAnalysis.self).sorted(byKeyPath: "whywhyAnalysisNo").last?.whywhyAnalysisNo ?? 0 }
-        analysis.whywhyAnalysisNo = maxWhywhyAnalysisNo + 1
+        let maxWhywhyAnalysisNo = try! Realm().objects(WhywhyAnalysis.self).sorted(byKeyPath: "whywhyAnalysisNo").last?.whywhyAnalysisNo
+        if maxWhywhyAnalysisNo != nil {
+            analysis.whywhyAnalysisNo = maxWhywhyAnalysisNo! + 1
+        } else {
+            analysis.whywhyAnalysisNo = 1
+        }
         // Realmデータベースを取得
         let realm = try! Realm()
         // データベースに追加

--- a/whywhyanalysisApp/Model/DataStorage.swift
+++ b/whywhyanalysisApp/Model/DataStorage.swift
@@ -24,12 +24,33 @@ class DataStorage {
     
     // 新規何故何故分析を追加
     func createWhyAnalyticsData(_ analysis:WhywhyAnalysis) {
+        // WhywhyAnalysisNoの最大値
+        var maxWhywhyAnalysisNo: Int { return try! Realm().objects(WhywhyAnalysis.self).sorted(byKeyPath: "whywhyAnalysisNo").last?.whywhyAnalysisNo ?? 0 }
+        analysis.whywhyAnalysisNo = maxWhywhyAnalysisNo + 1
         // Realmデータベースを取得
         let realm = try! Realm()
         // データベースに追加
         try! realm.write {
             realm.add(analysis)
         }
+    }
+    
+    // 何故何故分析を編集
+    func editWhyAnalyticsData(_ analysis:WhywhyAnalysis) {
+        // Realmデータベースを取得
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add(analysis, update: .all)
+        }
+    }
+    
+    // 特定の何故何故分析を取得
+    func loadWhywhyAnalytics(_ whywhyAnalysisNo:Int) -> WhywhyAnalysis {
+        // Realmデータベースを取得
+        let realm = try! Realm()
+        let analysisList =  realm.objects(WhywhyAnalysis.self).filter("whywhyAnalysisNo == %@", whywhyAnalysisNo)
+        
+        return analysisList[0]
     }
     
 }

--- a/whywhyanalysisApp/Model/WhywhyAnalysis.swift
+++ b/whywhyanalysisApp/Model/WhywhyAnalysis.swift
@@ -10,6 +10,9 @@ import Foundation
 import RealmSwift
 
 class WhywhyAnalysis: Object {
+    
+    // 何故何故分析No.(PRIMARY KEY)
+    @objc dynamic var whywhyAnalysisNo: Int = 0
     // 問題
     @objc dynamic var problem: String!
     // 対策
@@ -33,8 +36,16 @@ class WhywhyAnalysis: Object {
     // 分析回数
     @objc dynamic var whywhyanalysiscount = ""
     
+    //
+    @objc dynamic var status: String!
+    
+    override static func primaryKey() -> String? {
+        return "whywhyAnalysisNo"
+    }
+    
     convenience init(problem: String, measures: String, oneWhy: String,
-                     twoWhy: String, threeWhy: String, fourWhy:String, fiveWhy: String) {
+                     twoWhy: String, threeWhy: String, fourWhy:String,
+                     fiveWhy: String, status: String) {
         self.init()
         self.problem = problem
         self.measures = measures
@@ -43,5 +54,6 @@ class WhywhyAnalysis: Object {
         self.threeWhy = threeWhy
         self.fourWhy = fourWhy
         self.fiveWhy = fiveWhy
+        self.status = status
     }
 }

--- a/whywhyanalysisApp/View/AnalysisListCustumCell.swift
+++ b/whywhyanalysisApp/View/AnalysisListCustumCell.swift
@@ -9,11 +9,12 @@
 import UIKit
 
 class AnalysisListCustumCell: UITableViewCell {
-
+    
     @IBOutlet weak var measuresLabel: UILabel!
     
     @IBOutlet weak var problemLabel: UILabel!
     
+    @IBOutlet weak var statusLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()


### PR DESCRIPTION
    ## 実装内容概要
・なぜなぜ分析の編集機能を追加

## 実装詳細
・モデル.WhywhyAnalysisに
　・項目.ステータス、何故何故分析Noを追加（モデルクラスの編集)
　・主キーを追加

・カスタムセル .AnalysisListCustumCellに項目.ステータスを追加(画面編集)
・メインストーリーボード.Main.storyboardに項目.ステータスを追加(画面編集)

・コントローラー.RegistAnalysisViewControllerに項目.ステータスの処理(UIPickerView)を追加
・コントローラー.EditAnalysisViewControllerに項目.ステータスの処理を追加
・コントローラー.HomeViewControllerに項目.ステータスの処理を追加

・データベース編集.DataStorageに
　・メソッド.何故何故分析を編集、メソッド.特定の何故何故分析を取得を追加
　・メソッド.新規何故何故分析を追加に何故何故分析No.の処理を追加

## レビュー時の注意点
未実装部分
・デザインについては未実装です

レビュー時に注意して欲しいこと
以下を重点的に見ていただきたいです。
　・変数名やファイル名について適切な名前であるか
　・保守性(拡張性)の高いソースであるか(特にRegistAnalysisViewControllerを見ていただきたいです)
※ご指摘いただいた部分は今回、またはリファクタリングのタイミングで取り込みます。

以上、よろしくお願いいたします。
