### PR TITLE
各画面のレイアウトを修正しました。

### DIFF
--- a/whywhyanalysisApp/Src/Base.lproj/Main.storyboard
+++ b/whywhyanalysisApp/Src/Base.lproj/Main.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ptZ-HU-ALY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ptZ-HU-ALY">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -64,8 +66,8 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="aNG-LC-PO5">
-                                <rect key="frame" x="5" y="144" width="365" height="394"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <rect key="frame" x="5" y="144" width="365" height="374"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" id="tbG-8n-ukX">
                                         <rect key="frame" x="0.0" y="28" width="365" height="43.5"/>
@@ -78,19 +80,20 @@
                                 </prototypes>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VCc-vK-nei">
-                                <rect key="frame" x="315" y="559" width="40" height="37.5"/>
+                                <rect key="frame" x="295" y="539" width="60" height="57.5"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="0u7-3S-xsK"/>
-                                    <constraint firstAttribute="width" constant="40" id="WUm-l9-FDZ"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="jVr-jT-1W5"/>
+                                    <constraint firstAttribute="height" constant="60" id="4fO-gO-fmu"/>
+                                    <constraint firstAttribute="width" constant="60" id="hU2-lP-RFu"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <state key="normal" backgroundImage="plus.rectangle.fill" catalog="system"/>
                                 <connections>
                                     <action selector="addAnalysisClick:" destination="i5Z-bF-1Z8" eventType="touchUpInside" id="m2L-rI-fXZ"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="mxm-3s-Udb"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="WAa-rR-n2e" firstAttribute="top" secondItem="mxm-3s-Udb" secondAttribute="top" id="4We-2v-R9G"/>
                             <constraint firstItem="mxm-3s-Udb" firstAttribute="trailing" secondItem="VCc-vK-nei" secondAttribute="trailing" constant="20" id="7tL-ac-JU4"/>
@@ -103,7 +106,6 @@
                             <constraint firstItem="mxm-3s-Udb" firstAttribute="trailing" secondItem="WAa-rR-n2e" secondAttribute="trailing" id="jCM-3Q-krI"/>
                             <constraint firstItem="VCc-vK-nei" firstAttribute="top" secondItem="aNG-LC-PO5" secondAttribute="bottom" constant="20" id="x2a-ux-u1M"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="mxm-3s-Udb"/>
                     </view>
                     <navigationItem key="navigationItem" id="j7e-SV-J7M"/>
                     <connections>
@@ -124,44 +126,76 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dfk-ch-Glm">
-                                <rect key="frame" x="50" y="30" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dfk-ch-Glm">
+                                <rect key="frame" x="32.5" y="30" width="70" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="fun-Ns-fvO"/>
+                                    <constraint firstAttribute="height" constant="30" id="pmF-mT-XP0"/>
+                                </constraints>
                                 <state key="normal" title="実施中"/>
                                 <connections>
                                     <action selector="selectInProgressButton:" destination="bkt-m3-jRA" eventType="touchUpInside" id="j5j-Da-PKu"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rpQ-K2-TFB">
-                                <rect key="frame" x="172" y="30" width="31" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rpQ-K2-TFB">
+                                <rect key="frame" x="152.5" y="30" width="70" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="7hR-by-Qca"/>
+                                    <constraint firstAttribute="height" constant="30" id="PHl-X8-0Zc"/>
+                                </constraints>
                                 <state key="normal" title="達成"/>
                                 <connections>
                                     <action selector="selectAchieveButton:" destination="bkt-m3-jRA" eventType="touchUpInside" id="i57-Pd-mfo"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w76-MX-4Y8">
-                                <rect key="frame" x="279" y="30" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w76-MX-4Y8">
+                                <rect key="frame" x="272.5" y="30" width="70" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="5ry-dH-oUs"/>
+                                    <constraint firstAttribute="height" constant="30" id="Sn5-rJ-9Xm"/>
+                                </constraints>
                                 <state key="normal" title="未達成"/>
                                 <connections>
                                     <action selector="selectNotAchievedButton:" destination="bkt-m3-jRA" eventType="touchUpInside" id="TST-j6-26N"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dg3-52-LbT">
-                                <rect key="frame" x="15" y="101" width="345" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <nil key="textColor"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dg3-52-LbT">
+                                <rect key="frame" x="15" y="100" width="345" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="24" id="v4J-oQ-etk"/>
+                                </constraints>
+                                <attributedString key="attributedText">
+                                    <fragment content="対策ラベル">
+                                        <attributes>
+                                            <font key="NSFont" size="20" name=".HiraKakuInterface-W3"/>
+                                            <integer key="NSUnderline" value="1"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L80-mi-v55">
-                                <rect key="frame" x="15" y="140" width="345" height="20"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L80-mi-v55">
+                                <rect key="frame" x="15" y="139" width="345" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="PMM-MJ-KaF"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="VXR-Rl-XFu"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                <nil key="textColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="問題ラベル">
+                                        <attributes>
+                                            <font key="NSFont" size="16" name=".HiraKakuInterface-W3"/>
+                                            <integer key="NSUnderline" value="1"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6VA-04-1jm">
-                                <rect key="frame" x="167" y="190" width="41" height="36"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6VA-04-1jm">
+                                <rect key="frame" x="147.5" y="189" width="80" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="HR3-91-EHY"/>
+                                    <constraint firstAttribute="height" constant="40" id="cOl-P1-K7i"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <state key="normal" title="確定"/>
                                 <connections>
@@ -169,26 +203,25 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <constraints>
-                            <constraint firstItem="L80-mi-v55" firstAttribute="top" secondItem="Dg3-52-LbT" secondAttribute="bottom" constant="15" id="0UW-KY-nFy"/>
-                            <constraint firstItem="w76-MX-4Y8" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="3iv-W6-FAW"/>
-                            <constraint firstItem="Dfk-ch-Glm" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="8jJ-9A-zXS"/>
-                            <constraint firstItem="w76-MX-4Y8" firstAttribute="leading" secondItem="rpQ-K2-TFB" secondAttribute="trailing" constant="76" id="9Tk-SI-byQ"/>
-                            <constraint firstItem="Dfk-ch-Glm" firstAttribute="leading" secondItem="XY8-K6-UdQ" secondAttribute="leading" constant="50" id="C3f-la-5Yf"/>
-                            <constraint firstItem="XY8-K6-UdQ" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="w76-MX-4Y8" secondAttribute="trailing" symbolic="YES" id="LHm-al-w00"/>
-                            <constraint firstItem="L80-mi-v55" firstAttribute="leading" secondItem="XY8-K6-UdQ" secondAttribute="leading" constant="15" id="Ncx-f3-5bw"/>
-                            <constraint firstItem="XY8-K6-UdQ" firstAttribute="trailing" secondItem="Dg3-52-LbT" secondAttribute="trailing" constant="15" id="QrO-ib-wCw"/>
-                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Dfk-ch-Glm" secondAttribute="trailing" constant="8" symbolic="YES" id="R3d-b8-7ln"/>
-                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="centerX" secondItem="JhA-1C-wfB" secondAttribute="centerX" id="SQG-H8-1dD"/>
-                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="TAV-mA-2hH"/>
-                            <constraint firstItem="XY8-K6-UdQ" firstAttribute="trailing" secondItem="L80-mi-v55" secondAttribute="trailing" constant="15" id="e1f-3m-1Rs"/>
-                            <constraint firstItem="Dg3-52-LbT" firstAttribute="top" secondItem="Dfk-ch-Glm" secondAttribute="bottom" constant="41" id="fKK-hd-ZLg" userLabel="対策ラベル.top = 実施中.bottom + 40"/>
-                            <constraint firstItem="6VA-04-1jm" firstAttribute="centerX" secondItem="JhA-1C-wfB" secondAttribute="centerX" id="irY-Im-zUM"/>
-                            <constraint firstItem="6VA-04-1jm" firstAttribute="top" secondItem="L80-mi-v55" secondAttribute="bottom" constant="30" id="m7S-31-TUR"/>
-                            <constraint firstItem="Dg3-52-LbT" firstAttribute="leading" secondItem="XY8-K6-UdQ" secondAttribute="leading" constant="15" id="ouH-nX-ANC"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="XY8-K6-UdQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Dg3-52-LbT" firstAttribute="top" secondItem="Dfk-ch-Glm" secondAttribute="bottom" constant="40" id="1Uj-ls-8De"/>
+                            <constraint firstItem="XY8-K6-UdQ" firstAttribute="trailing" secondItem="L80-mi-v55" secondAttribute="trailing" constant="15" id="1n4-AS-zOj"/>
+                            <constraint firstItem="L80-mi-v55" firstAttribute="leading" secondItem="XY8-K6-UdQ" secondAttribute="leading" constant="15" id="Aoh-Sa-qqS"/>
+                            <constraint firstItem="XY8-K6-UdQ" firstAttribute="trailing" secondItem="Dg3-52-LbT" secondAttribute="trailing" constant="15" id="HNW-bw-thz"/>
+                            <constraint firstItem="6VA-04-1jm" firstAttribute="top" secondItem="L80-mi-v55" secondAttribute="bottom" constant="30" id="Hne-o1-L7u"/>
+                            <constraint firstItem="6VA-04-1jm" firstAttribute="centerX" secondItem="JhA-1C-wfB" secondAttribute="centerX" id="TCh-ba-2Qg"/>
+                            <constraint firstItem="L80-mi-v55" firstAttribute="top" secondItem="Dg3-52-LbT" secondAttribute="bottom" constant="15" id="Ttk-Qd-FxO"/>
+                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="VUI-dx-7ws"/>
+                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="leading" secondItem="Dfk-ch-Glm" secondAttribute="trailing" constant="50" id="bjR-di-UEQ"/>
+                            <constraint firstItem="Dfk-ch-Glm" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="ckW-PQ-rKM"/>
+                            <constraint firstItem="rpQ-K2-TFB" firstAttribute="centerX" secondItem="JhA-1C-wfB" secondAttribute="centerX" id="iYC-3B-IcG"/>
+                            <constraint firstItem="w76-MX-4Y8" firstAttribute="leading" secondItem="rpQ-K2-TFB" secondAttribute="trailing" constant="50" id="l1E-HT-W97"/>
+                            <constraint firstItem="Dg3-52-LbT" firstAttribute="leading" secondItem="XY8-K6-UdQ" secondAttribute="leading" constant="15" id="l1m-EC-tDW"/>
+                            <constraint firstItem="6VA-04-1jm" firstAttribute="centerX" secondItem="JhA-1C-wfB" secondAttribute="centerX" id="oup-7S-VLE"/>
+                            <constraint firstItem="w76-MX-4Y8" firstAttribute="top" secondItem="XY8-K6-UdQ" secondAttribute="top" constant="30" id="v2U-kQ-eKz"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="achieveButton" destination="rpQ-K2-TFB" id="If8-t7-CyS"/>
@@ -201,17 +234,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MBF-wY-akp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1923" y="822"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="foS-4N-frJ">
-            <objects>
-                <viewController id="mtO-VS-lCf" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="20E-bX-a1d"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="i6U-sH-emt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2098" y="2223"/>
+            <point key="canvasLocation" x="1921.9626168224297" y="821.59827213822905"/>
         </scene>
         <!--Edit Analysis View Controller-->
         <scene sceneID="Mjz-vy-vxn">
@@ -220,8 +243,8 @@
                     <view key="view" contentMode="scaleToFill" id="Evn-cC-pEY" customClass="WhywhyAnalysisCell" customModule="whywhyanalysisApp" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="cNc-6O-OhW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="X41-aX-LiH"/>
                 </viewController>
@@ -243,22 +266,35 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e8y-gs-tY0">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e8y-gs-tY0">
                                 <rect key="frame" x="170" y="110" width="35" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="boA-9u-0B3"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="問題">
+                                        <attributes>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btg-5T-evG">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btg-5T-evG">
                                 <rect key="frame" x="10" y="155" width="355" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="7TY-S5-Aog"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="問題ラベル　　　　　　　　　　　　">
+                                        <attributes>
+                                            <font key="NSFont" size="17" name=".HiraKakuInterface-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                            <integer key="NSUnderline" value="1"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1tG-E1-bXU">
@@ -270,20 +306,27 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策ラベル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mcn-8Z-duW">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mcn-8Z-duW">
                                 <rect key="frame" x="10" y="240" width="355" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="60o-HU-uXN"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="対策ラベル">
+                                        <attributes>
+                                            <font key="NSFont" size="17" name=".HiraKakuInterface-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                            <integer key="NSUnderline" value="1"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" restorationIdentifier="confirmButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="89t-s4-tNp">
-                                <rect key="frame" x="137.5" y="571" width="100" height="40"/>
+                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" restorationIdentifier="confirmButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="89t-s4-tNp">
+                                <rect key="frame" x="147.5" y="440" width="80" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="SyW-xr-IBe"/>
-                                    <constraint firstAttribute="width" constant="100" id="feZ-9I-Kzi"/>
+                                    <constraint firstAttribute="width" constant="80" id="TzM-a0-on6"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <state key="normal" title="登録"/>
@@ -305,7 +348,8 @@
                                 </constraints>
                             </pickerView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="oAB-IA-Fqg"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" secondItem="dj1-LE-BKz" secondAttribute="trailing" constant="49" id="2WT-Gv-qkt"/>
                             <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" secondItem="mcn-8Z-duW" secondAttribute="trailing" constant="10" id="2cq-6E-SQN"/>
@@ -321,14 +365,13 @@
                             <constraint firstItem="dj1-LE-BKz" firstAttribute="top" secondItem="mcn-8Z-duW" secondAttribute="bottom" constant="15" id="Xxs-1z-fdY"/>
                             <constraint firstItem="Umt-pK-rzv" firstAttribute="centerX" secondItem="e8y-gs-tY0" secondAttribute="centerX" id="Ya6-39-ki9"/>
                             <constraint firstItem="Umt-pK-rzv" firstAttribute="top" secondItem="oAB-IA-Fqg" secondAttribute="top" constant="60" id="ct3-Zx-5W3"/>
-                            <constraint firstItem="oAB-IA-Fqg" firstAttribute="bottom" secondItem="89t-s4-tNp" secondAttribute="bottom" constant="56" id="d0s-Kr-29k"/>
+                            <constraint firstItem="89t-s4-tNp" firstAttribute="top" secondItem="dj1-LE-BKz" secondAttribute="bottom" constant="100" id="jZJ-Ev-V2V"/>
                             <constraint firstItem="e8y-gs-tY0" firstAttribute="centerX" secondItem="IJH-zM-e91" secondAttribute="centerX" id="nii-oU-Q5C"/>
                             <constraint firstItem="btg-5T-evG" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="10" id="ved-tR-Wra"/>
                             <constraint firstItem="oAB-IA-Fqg" firstAttribute="trailing" secondItem="mcn-8Z-duW" secondAttribute="trailing" constant="10" id="vhZ-q2-XRH"/>
                             <constraint firstItem="mcn-8Z-duW" firstAttribute="top" secondItem="1tG-E1-bXU" secondAttribute="bottom" constant="15" id="w0J-jm-3Y3"/>
                             <constraint firstItem="mcn-8Z-duW" firstAttribute="leading" secondItem="oAB-IA-Fqg" secondAttribute="leading" constant="10" id="zCe-xT-T9r"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="oAB-IA-Fqg"/>
                     </view>
                     <navigationItem key="navigationItem" id="dJr-P2-uCq"/>
                     <connections>
@@ -383,5 +426,8 @@
         <image name="house.fill" catalog="system" width="128" height="106"/>
         <image name="person.circle.fill" catalog="system" width="128" height="121"/>
         <image name="plus.rectangle.fill" catalog="system" width="128" height="93"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/whywhyanalysisApp/Src/Controller/ShowAnalysisListViewController.swift
+++ b/whywhyanalysisApp/Src/Controller/ShowAnalysisListViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 internal class ShowAnalysisListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     internal var whywhyAnalysisList: [Analysis] = []
-    internal let cellHeigh: CGFloat = 100
+    internal let cellHeigh: CGFloat = 130
     @IBOutlet internal weak var tableView: UITableView!
     @IBOutlet internal weak var titleLabel: UILabel!
     @IBOutlet internal weak var backgroundView: UIView!
@@ -38,6 +38,7 @@ internal class ShowAnalysisListViewController: UIViewController, UITableViewData
         backgroundView.backgroundColor = AppColor.viewBgColor
         titleLabel.layer.borderColor = UIColor.link.cgColor
         tableView.separatorColor = AppColor.tableBgColor
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         titleLabel.layer.borderWidth = 1
     }
 
@@ -105,12 +106,12 @@ internal class ShowAnalysisListViewController: UIViewController, UITableViewData
         let row = whywhyAnalysisList.count - indexPath.row - 1
         if let cell = cell {
             if  let problem = whywhyAnalysisList[row].problem {
-                cell.problemLabel.text = problem
+                cell.problemLabel.text = "問題：" + problem
             } else {
                 // TODO: 後ほどエラー処理を実装
             }
             if let measure = whywhyAnalysisList[row].measures {
-                cell.measuresLabel.text = measure
+                cell.measuresLabel.text = "対策：" + measure
             } else {
                 // TODO: 後ほどエラー処理を実装
             }

--- a/whywhyanalysisApp/Src/View/EditAnalysis.swift
+++ b/whywhyanalysisApp/Src/View/EditAnalysis.swift
@@ -23,7 +23,14 @@ internal class EditAnalysis: UIView, UITextFieldDelegate, UIScrollViewDelegate {
     @IBOutlet internal weak var fourWhyTextField: UITextField!
     @IBOutlet internal weak var fiveWhyTextField: UITextField!
     @IBOutlet internal weak var measuresTextField: UITextField!
-    @IBOutlet internal weak var analysisView: UIView!
+
+    @IBOutlet internal weak var problemView: UIView!
+    @IBOutlet internal weak var oneAnalysisView: UIView!
+    @IBOutlet internal weak var twoAnalysisView: UIView!
+    @IBOutlet internal weak var threeAnalysisView: UIView!
+    @IBOutlet internal weak var fourAnalysisView: UIView!
+    @IBOutlet internal weak var fiveAnalysisView: UIView!
+
     @IBOutlet internal weak var measuresLabel: UILabel!
     @IBOutlet internal weak var confirmButton: UIButton!
     @IBOutlet internal weak var oneArrow: UIImageView!
@@ -53,7 +60,13 @@ internal class EditAnalysis: UIView, UITextFieldDelegate, UIScrollViewDelegate {
         fourArrow.tintColor = AppColor.mainColor
         fiveArrow.tintColor = AppColor.mainColor
 
-        analysisView.backgroundColor = AppColor.viewBgColor
+        problemView.backgroundColor = AppColor.viewBgColor
+        oneAnalysisView.backgroundColor = AppColor.viewBgColor
+        twoAnalysisView.backgroundColor = AppColor.viewBgColor
+        threeAnalysisView.backgroundColor = AppColor.viewBgColor
+        fourAnalysisView.backgroundColor = AppColor.viewBgColor
+        fiveAnalysisView.backgroundColor = AppColor.viewBgColor
+
         measuresLabel.backgroundColor = AppColor.headingLabelBgColor
         measuresLabel.textColor = .white
         confirmButton.backgroundColor = AppColor.btnBgColor

--- a/whywhyanalysisApp/Src/View/EditAnalysis.xib
+++ b/whywhyanalysisApp/Src/View/EditAnalysis.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -12,319 +12,500 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="EditAnalysis" customModule="whywhyanalysisApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1c2-cp-ylY">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="537"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dt4-m7-yZD" userLabel="baseView">
+                    <rect key="frame" x="0.0" y="44" width="428" height="828"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BCF-qr-j9X">
-                            <rect key="frame" x="10" y="138.5" width="50" height="20"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1fy-10-fnT" userLabel="upView">
+                            <rect key="frame" x="0.0" y="0.0" width="428" height="538.33333333333337"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NqV-K0-N6Z" userLabel="problemView">
+                                    <rect key="frame" x="0.0" y="0.0" width="428" height="80.666666666666671"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="問題：" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="glL-J5-IDO">
+                                            <rect key="frame" x="10" y="23" width="408" height="35"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="35" id="jco-vK-5AU"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="glL-J5-IDO" secondAttribute="trailing" constant="10" id="GVh-oS-G7T"/>
+                                        <constraint firstItem="glL-J5-IDO" firstAttribute="centerX" secondItem="NqV-K0-N6Z" secondAttribute="centerX" id="Tio-TU-vIp"/>
+                                        <constraint firstItem="glL-J5-IDO" firstAttribute="leading" secondItem="NqV-K0-N6Z" secondAttribute="leading" constant="10" id="Wlt-bm-NG6"/>
+                                        <constraint firstItem="glL-J5-IDO" firstAttribute="centerY" secondItem="NqV-K0-N6Z" secondAttribute="centerY" id="Zun-XJ-Ffg"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zBp-2R-28m">
+                                    <rect key="frame" x="0.0" y="80.666666666666657" width="428" height="457.66666666666674"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NQw-Bi-NAF" userLabel="oneAnalysisView">
+                                            <rect key="frame" x="0.0" y="0.0" width="428" height="91.666666666666671"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c9W-Nc-U0A">
+                                                    <rect key="frame" x="169" y="-5" width="90" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="VlN-aZ-JXU"/>
+                                                        <constraint firstAttribute="width" constant="90" id="YPi-g7-Jro"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="2G9-Sa-Qgp">
+                                                    <rect key="frame" x="139" y="-3.6666666666666679" width="20" height="30.333333333333332"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="20" id="t40-5s-FPb"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OOK-J0-VcV">
+                                                    <rect key="frame" x="5" y="30.666666666666671" width="55" height="30"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="55" id="QGK-mc-tf2"/>
+                                                        <constraint firstAttribute="height" constant="30" id="erj-ka-Fgj"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tMG-Af-eBB">
+                                                    <rect key="frame" x="65" y="30.666666666666671" width="353" height="30"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="30" id="Sd0-5L-byr"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstItem="OOK-J0-VcV" firstAttribute="leading" secondItem="NQw-Bi-NAF" secondAttribute="leading" constant="5" id="5aN-vC-JnC"/>
+                                                <constraint firstAttribute="trailing" secondItem="tMG-Af-eBB" secondAttribute="trailing" constant="10" id="Hoa-Zz-QAr"/>
+                                                <constraint firstItem="tMG-Af-eBB" firstAttribute="top" secondItem="2G9-Sa-Qgp" secondAttribute="bottom" constant="3" id="KJN-oE-KnS"/>
+                                                <constraint firstItem="c9W-Nc-U0A" firstAttribute="top" secondItem="NQw-Bi-NAF" secondAttribute="top" constant="-5" id="PYm-TY-h50"/>
+                                                <constraint firstItem="OOK-J0-VcV" firstAttribute="centerY" secondItem="NQw-Bi-NAF" secondAttribute="centerY" id="Q38-Jv-NEW"/>
+                                                <constraint firstItem="tMG-Af-eBB" firstAttribute="leading" secondItem="OOK-J0-VcV" secondAttribute="trailing" constant="5" id="QVf-b0-khK"/>
+                                                <constraint firstItem="c9W-Nc-U0A" firstAttribute="leading" secondItem="2G9-Sa-Qgp" secondAttribute="trailing" constant="10" id="bLX-IG-ngh"/>
+                                                <constraint firstItem="tMG-Af-eBB" firstAttribute="centerY" secondItem="NQw-Bi-NAF" secondAttribute="centerY" id="bdV-SG-Np1"/>
+                                                <constraint firstItem="2G9-Sa-Qgp" firstAttribute="top" secondItem="NQw-Bi-NAF" secondAttribute="top" constant="-5" id="cNg-ZD-fsc"/>
+                                                <constraint firstItem="c9W-Nc-U0A" firstAttribute="centerX" secondItem="NQw-Bi-NAF" secondAttribute="centerX" id="mAB-IF-Zyi"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gly-Iv-c01">
+                                            <rect key="frame" x="0.0" y="91.666666666666686" width="428" height="366"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wDl-p0-BhU" userLabel="twoAnalysisView">
+                                                    <rect key="frame" x="0.0" y="0.0" width="428" height="91.333333333333329"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4uT-wX-igN">
+                                                            <rect key="frame" x="169" y="-5" width="90" height="28.666666666666668"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="90" id="yP0-ZF-pga"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="cvv-Ge-kzy">
+                                                            <rect key="frame" x="139" y="-3.6666666666666679" width="20" height="26.333333333333336"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="20" id="Gts-SY-c9E"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aCt-mf-JsX">
+                                                            <rect key="frame" x="5" y="30.666666666666657" width="55" height="30"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="30" id="aKf-r1-MGY"/>
+                                                                <constraint firstAttribute="width" constant="55" id="afB-Cd-AnS"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="n6p-XP-pak">
+                                                            <rect key="frame" x="65" y="30.666666666666657" width="353" height="30"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="30" id="6pO-2P-sbD"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits"/>
+                                                        </textField>
+                                                    </subviews>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <constraints>
+                                                        <constraint firstItem="cvv-Ge-kzy" firstAttribute="top" secondItem="wDl-p0-BhU" secondAttribute="top" constant="-5" id="06U-5Z-XeM"/>
+                                                        <constraint firstItem="aCt-mf-JsX" firstAttribute="top" secondItem="n6p-XP-pak" secondAttribute="top" id="Cdg-J9-b8o"/>
+                                                        <constraint firstItem="aCt-mf-JsX" firstAttribute="leading" secondItem="wDl-p0-BhU" secondAttribute="leading" constant="5" id="JaP-nH-foH"/>
+                                                        <constraint firstItem="n6p-XP-pak" firstAttribute="top" secondItem="4uT-wX-igN" secondAttribute="bottom" constant="7" id="UBD-Yx-tAm"/>
+                                                        <constraint firstItem="4uT-wX-igN" firstAttribute="leading" secondItem="cvv-Ge-kzy" secondAttribute="trailing" constant="10" id="Umf-Bj-ppY"/>
+                                                        <constraint firstAttribute="trailing" secondItem="n6p-XP-pak" secondAttribute="trailing" constant="10" id="fkM-CZ-AHv"/>
+                                                        <constraint firstItem="n6p-XP-pak" firstAttribute="top" secondItem="cvv-Ge-kzy" secondAttribute="bottom" constant="7" id="gAi-EU-F8g"/>
+                                                        <constraint firstItem="n6p-XP-pak" firstAttribute="leading" secondItem="aCt-mf-JsX" secondAttribute="trailing" constant="5" id="jXm-hv-hZ6"/>
+                                                        <constraint firstItem="4uT-wX-igN" firstAttribute="centerX" secondItem="wDl-p0-BhU" secondAttribute="centerX" id="kgx-3y-RUL"/>
+                                                        <constraint firstItem="aCt-mf-JsX" firstAttribute="centerY" secondItem="wDl-p0-BhU" secondAttribute="centerY" id="saq-an-Szz"/>
+                                                        <constraint firstItem="4uT-wX-igN" firstAttribute="top" secondItem="wDl-p0-BhU" secondAttribute="top" constant="-5" id="wCz-U3-P50"/>
+                                                    </constraints>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yxa-7G-Nfq">
+                                                    <rect key="frame" x="0.0" y="91.333333333333343" width="428" height="274.66666666666663"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aEZ-hG-eOG" userLabel="threeAnalysisView">
+                                                            <rect key="frame" x="0.0" y="0.0" width="428" height="90.666666666666671"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j1o-gJ-ui8">
+                                                                    <rect key="frame" x="5" y="30.333333333333314" width="55" height="30"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="55" id="b6b-vQ-Po7"/>
+                                                                        <constraint firstAttribute="height" constant="30" id="p7Q-rl-hHR"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xPN-h8-8Xr">
+                                                                    <rect key="frame" x="65" y="30.333333333333314" width="353" height="30"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="30" id="FLA-Uh-QQ7"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <textInputTraits key="textInputTraits"/>
+                                                                </textField>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mfG-dX-prl">
+                                                                    <rect key="frame" x="169" y="-8" width="90" height="17"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="90" id="dxo-U1-RTF"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="EfZ-a8-g4J">
+                                                                    <rect key="frame" x="139" y="-3.6666666666666679" width="20" height="18"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="20" id="CJP-mh-hwB"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                            </subviews>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                            <constraints>
+                                                                <constraint firstItem="mfG-dX-prl" firstAttribute="top" secondItem="aEZ-hG-eOG" secondAttribute="top" constant="-8" id="AdD-Jl-XmI"/>
+                                                                <constraint firstAttribute="trailing" secondItem="xPN-h8-8Xr" secondAttribute="trailing" constant="10" id="MvZ-ef-QhR"/>
+                                                                <constraint firstItem="j1o-gJ-ui8" firstAttribute="leading" secondItem="aEZ-hG-eOG" secondAttribute="leading" constant="5" id="PMs-Ra-VXQ"/>
+                                                                <constraint firstItem="EfZ-a8-g4J" firstAttribute="top" secondItem="aEZ-hG-eOG" secondAttribute="top" constant="-5" id="ZJM-UG-zrh"/>
+                                                                <constraint firstItem="j1o-gJ-ui8" firstAttribute="centerY" secondItem="aEZ-hG-eOG" secondAttribute="centerY" id="dyb-E6-i5i"/>
+                                                                <constraint firstItem="xPN-h8-8Xr" firstAttribute="centerY" secondItem="j1o-gJ-ui8" secondAttribute="centerY" id="jPa-q0-oAl"/>
+                                                                <constraint firstItem="xPN-h8-8Xr" firstAttribute="leading" secondItem="j1o-gJ-ui8" secondAttribute="trailing" constant="5" id="kwy-Wg-NhL"/>
+                                                                <constraint firstItem="mfG-dX-prl" firstAttribute="leading" secondItem="EfZ-a8-g4J" secondAttribute="trailing" constant="10" id="nvN-8E-Afz"/>
+                                                                <constraint firstItem="mfG-dX-prl" firstAttribute="centerX" secondItem="aEZ-hG-eOG" secondAttribute="centerX" id="oDX-LE-Bkx"/>
+                                                                <constraint firstItem="EfZ-a8-g4J" firstAttribute="top" secondItem="aEZ-hG-eOG" secondAttribute="top" constant="-5" id="xzw-RT-iin"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pnm-pz-0wz">
+                                                            <rect key="frame" x="0.0" y="90.666666666666629" width="428" height="184"/>
+                                                            <subviews>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vfs-sW-BFV" userLabel="fourAnalysisView">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="428" height="92"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2nC-sd-jjF">
+                                                                            <rect key="frame" x="169" y="-5" width="90" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="90" id="yHU-wI-MVj"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                            <nil key="textColor"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="AvI-8g-uwR">
+                                                                            <rect key="frame" x="139" y="-3.6666666666666679" width="20" height="18"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="20" id="1fS-3z-EuH"/>
+                                                                            </constraints>
+                                                                        </imageView>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hve-z1-9Zj">
+                                                                            <rect key="frame" x="5" y="31" width="55" height="30"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="55" id="27h-AQ-yqR"/>
+                                                                                <constraint firstAttribute="height" constant="30" id="rsJ-6x-Onf"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                                            <nil key="textColor"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8vt-43-NNq">
+                                                                            <rect key="frame" x="65" y="29" width="353" height="34"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                            <textInputTraits key="textInputTraits"/>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    <constraints>
+                                                                        <constraint firstItem="hve-z1-9Zj" firstAttribute="leading" secondItem="vfs-sW-BFV" secondAttribute="leading" constant="5" id="7dL-U4-aYA"/>
+                                                                        <constraint firstItem="hve-z1-9Zj" firstAttribute="centerY" secondItem="vfs-sW-BFV" secondAttribute="centerY" id="DWf-vr-fOf"/>
+                                                                        <constraint firstItem="2nC-sd-jjF" firstAttribute="top" secondItem="vfs-sW-BFV" secondAttribute="top" constant="-5" id="Efr-aN-Ya8"/>
+                                                                        <constraint firstItem="2nC-sd-jjF" firstAttribute="centerX" secondItem="vfs-sW-BFV" secondAttribute="centerX" id="QB1-av-Gmc"/>
+                                                                        <constraint firstItem="AvI-8g-uwR" firstAttribute="top" secondItem="vfs-sW-BFV" secondAttribute="top" constant="-5" id="TLY-Ws-H9J"/>
+                                                                        <constraint firstItem="2nC-sd-jjF" firstAttribute="leading" secondItem="AvI-8g-uwR" secondAttribute="trailing" constant="10" id="UEL-E0-9eQ"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="8vt-43-NNq" secondAttribute="trailing" constant="10" id="aja-AO-eVV"/>
+                                                                        <constraint firstItem="8vt-43-NNq" firstAttribute="centerY" secondItem="vfs-sW-BFV" secondAttribute="centerY" id="nZw-2j-3Wi"/>
+                                                                        <constraint firstItem="8vt-43-NNq" firstAttribute="leading" secondItem="hve-z1-9Zj" secondAttribute="trailing" constant="5" id="s6w-tA-4Ab"/>
+                                                                    </constraints>
+                                                                </view>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vz6-6V-icK" userLabel="fiveAnalysisView">
+                                                                    <rect key="frame" x="0.0" y="92" width="428" height="92"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kjt-U6-jBt">
+                                                                            <rect key="frame" x="169" y="-5" width="90" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="90" id="Ho1-js-15n"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                            <nil key="textColor"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="2fX-X4-W2g">
+                                                                            <rect key="frame" x="139" y="-3.6666666666666679" width="20" height="18"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="20" id="32G-kJ-DbF"/>
+                                                                            </constraints>
+                                                                        </imageView>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XF8-4D-BTK">
+                                                                            <rect key="frame" x="5" y="31.000000000000057" width="55" height="30"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="30" id="HA1-66-z4A"/>
+                                                                                <constraint firstAttribute="width" constant="55" id="gYX-cK-J4I"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                                            <nil key="textColor"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O91-kj-jIv">
+                                                                            <rect key="frame" x="65" y="29.000000000000057" width="353" height="34"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                            <textInputTraits key="textInputTraits"/>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    <constraints>
+                                                                        <constraint firstItem="kjt-U6-jBt" firstAttribute="top" secondItem="vz6-6V-icK" secondAttribute="top" constant="-5" id="3rG-Ba-wZm"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="O91-kj-jIv" secondAttribute="trailing" constant="10" id="Fgu-bQ-feR"/>
+                                                                        <constraint firstItem="XF8-4D-BTK" firstAttribute="centerY" secondItem="vz6-6V-icK" secondAttribute="centerY" id="MWP-df-MgU"/>
+                                                                        <constraint firstItem="2fX-X4-W2g" firstAttribute="top" secondItem="vz6-6V-icK" secondAttribute="top" constant="-5" id="UF3-9d-3Fp"/>
+                                                                        <constraint firstItem="XF8-4D-BTK" firstAttribute="leading" secondItem="vz6-6V-icK" secondAttribute="leading" constant="5" id="VFv-Sa-MDZ"/>
+                                                                        <constraint firstItem="O91-kj-jIv" firstAttribute="leading" secondItem="XF8-4D-BTK" secondAttribute="trailing" constant="5" id="dcF-Ac-9JR"/>
+                                                                        <constraint firstItem="O91-kj-jIv" firstAttribute="centerY" secondItem="vz6-6V-icK" secondAttribute="centerY" id="gtM-pD-7ga"/>
+                                                                        <constraint firstItem="kjt-U6-jBt" firstAttribute="leading" secondItem="2fX-X4-W2g" secondAttribute="trailing" constant="10" id="v61-g3-xAK"/>
+                                                                        <constraint firstItem="kjt-U6-jBt" firstAttribute="centerX" secondItem="vz6-6V-icK" secondAttribute="centerX" id="zul-TY-2dM"/>
+                                                                    </constraints>
+                                                                </view>
+                                                            </subviews>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                            <constraints>
+                                                                <constraint firstItem="vz6-6V-icK" firstAttribute="leading" secondItem="Pnm-pz-0wz" secondAttribute="leading" id="4Ie-qT-L1O"/>
+                                                                <constraint firstItem="vfs-sW-BFV" firstAttribute="leading" secondItem="Pnm-pz-0wz" secondAttribute="leading" id="A2D-2K-4wD"/>
+                                                                <constraint firstItem="vfs-sW-BFV" firstAttribute="top" secondItem="Pnm-pz-0wz" secondAttribute="top" id="C6o-CO-0la"/>
+                                                                <constraint firstItem="vz6-6V-icK" firstAttribute="height" secondItem="Pnm-pz-0wz" secondAttribute="height" multiplier="0.5" id="CCD-5n-SW6"/>
+                                                                <constraint firstAttribute="trailing" secondItem="vfs-sW-BFV" secondAttribute="trailing" id="EI7-TL-RuV"/>
+                                                                <constraint firstAttribute="trailing" secondItem="vz6-6V-icK" secondAttribute="trailing" id="Wlq-Ct-1pf"/>
+                                                                <constraint firstItem="vfs-sW-BFV" firstAttribute="height" secondItem="Pnm-pz-0wz" secondAttribute="height" multiplier="0.5" id="jNs-H8-osj"/>
+                                                                <constraint firstAttribute="bottom" secondItem="vz6-6V-icK" secondAttribute="bottom" id="yIc-E7-fiZ"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                    <color key="backgroundColor" systemColor="systemGray2Color"/>
+                                                    <constraints>
+                                                        <constraint firstItem="aEZ-hG-eOG" firstAttribute="height" secondItem="yxa-7G-Nfq" secondAttribute="height" multiplier="0.33" id="Bsh-Tz-2Ni"/>
+                                                        <constraint firstItem="aEZ-hG-eOG" firstAttribute="top" secondItem="yxa-7G-Nfq" secondAttribute="top" id="CIu-h2-5bA"/>
+                                                        <constraint firstItem="Pnm-pz-0wz" firstAttribute="top" secondItem="aEZ-hG-eOG" secondAttribute="bottom" id="DGB-tv-0hF"/>
+                                                        <constraint firstItem="Pnm-pz-0wz" firstAttribute="leading" secondItem="yxa-7G-Nfq" secondAttribute="leading" id="fag-eZ-8Se"/>
+                                                        <constraint firstItem="Pnm-pz-0wz" firstAttribute="height" secondItem="yxa-7G-Nfq" secondAttribute="height" multiplier="0.67" id="hdh-Ng-j48"/>
+                                                        <constraint firstAttribute="trailing" secondItem="aEZ-hG-eOG" secondAttribute="trailing" id="lSe-5T-ARG"/>
+                                                        <constraint firstItem="aEZ-hG-eOG" firstAttribute="leading" secondItem="yxa-7G-Nfq" secondAttribute="leading" id="mvr-vB-jVj"/>
+                                                        <constraint firstAttribute="trailing" secondItem="Pnm-pz-0wz" secondAttribute="trailing" id="qE8-Ua-Hbd"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemGray2Color"/>
+                                            <constraints>
+                                                <constraint firstItem="yxa-7G-Nfq" firstAttribute="leading" secondItem="gly-Iv-c01" secondAttribute="leading" id="3TC-ax-BUb"/>
+                                                <constraint firstAttribute="bottom" secondItem="yxa-7G-Nfq" secondAttribute="bottom" id="CPH-eh-f8D"/>
+                                                <constraint firstAttribute="trailing" secondItem="wDl-p0-BhU" secondAttribute="trailing" id="Foc-QF-xHV"/>
+                                                <constraint firstItem="wDl-p0-BhU" firstAttribute="height" secondItem="gly-Iv-c01" secondAttribute="height" multiplier="0.25" id="NMC-ka-2sC"/>
+                                                <constraint firstItem="wDl-p0-BhU" firstAttribute="leading" secondItem="gly-Iv-c01" secondAttribute="leading" id="Qr9-Qw-gL2"/>
+                                                <constraint firstItem="wDl-p0-BhU" firstAttribute="top" secondItem="gly-Iv-c01" secondAttribute="top" id="iuu-kO-l3V"/>
+                                                <constraint firstAttribute="trailing" secondItem="yxa-7G-Nfq" secondAttribute="trailing" id="pI2-Kr-1hO"/>
+                                                <constraint firstItem="yxa-7G-Nfq" firstAttribute="height" secondItem="gly-Iv-c01" secondAttribute="height" multiplier="0.75" id="tc9-yM-wPX"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="gly-Iv-c01" secondAttribute="bottom" id="4B1-pH-TEJ"/>
+                                        <constraint firstItem="NQw-Bi-NAF" firstAttribute="top" secondItem="zBp-2R-28m" secondAttribute="top" id="4Rd-Rf-CRg"/>
+                                        <constraint firstAttribute="trailing" secondItem="gly-Iv-c01" secondAttribute="trailing" id="8cC-5V-If3"/>
+                                        <constraint firstItem="gly-Iv-c01" firstAttribute="leading" secondItem="zBp-2R-28m" secondAttribute="leading" id="DgK-eB-t6T"/>
+                                        <constraint firstItem="gly-Iv-c01" firstAttribute="height" secondItem="zBp-2R-28m" secondAttribute="height" multiplier="0.8" id="GiE-lr-m3n"/>
+                                        <constraint firstItem="NQw-Bi-NAF" firstAttribute="leading" secondItem="zBp-2R-28m" secondAttribute="leading" id="Jpu-wl-gsr"/>
+                                        <constraint firstItem="NQw-Bi-NAF" firstAttribute="height" secondItem="zBp-2R-28m" secondAttribute="height" multiplier="0.2" id="ZWT-OZ-fUt"/>
+                                        <constraint firstAttribute="trailing" secondItem="NQw-Bi-NAF" secondAttribute="trailing" id="r6F-mt-69x"/>
+                                        <constraint firstAttribute="bottom" secondItem="gly-Iv-c01" secondAttribute="bottom" id="y3v-Fz-pJc"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="ov9-Bd-cjm"/>
-                                <constraint firstAttribute="width" constant="50" id="wsg-Go-jaO"/>
+                                <constraint firstItem="NqV-K0-N6Z" firstAttribute="height" secondItem="1fy-10-fnT" secondAttribute="height" multiplier="0.15" id="4u5-4X-KDa"/>
+                                <constraint firstItem="NqV-K0-N6Z" firstAttribute="leading" secondItem="1fy-10-fnT" secondAttribute="leading" id="5Ft-0V-gBv"/>
+                                <constraint firstItem="zBp-2R-28m" firstAttribute="leading" secondItem="1fy-10-fnT" secondAttribute="leading" id="IIh-PW-gPM"/>
+                                <constraint firstAttribute="bottom" secondItem="zBp-2R-28m" secondAttribute="bottom" id="JjH-am-f01"/>
+                                <constraint firstItem="zBp-2R-28m" firstAttribute="height" secondItem="1fy-10-fnT" secondAttribute="height" multiplier="0.85" id="Lh7-rr-jJO"/>
+                                <constraint firstAttribute="trailing" secondItem="zBp-2R-28m" secondAttribute="trailing" id="mBs-Aa-7fq"/>
+                                <constraint firstAttribute="trailing" secondItem="NqV-K0-N6Z" secondAttribute="trailing" id="tvZ-Gc-ore"/>
+                                <constraint firstItem="NqV-K0-N6Z" firstAttribute="top" secondItem="1fy-10-fnT" secondAttribute="top" id="vj7-PL-h59"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xjS-nl-j7W">
-                            <rect key="frame" x="70" y="131" width="295" height="35"/>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bln-An-VTS" userLabel="bottomView">
+                            <rect key="frame" x="0.0" y="538.33333333333337" width="428" height="289.66666666666663"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xO1-aG-STK" userLabel="measuresView">
+                                    <rect key="frame" x="0.0" y="0.0" width="428" height="173.66666666666666"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VMH-Ol-pV3">
+                                            <rect key="frame" x="164" y="73.666666666666629" width="100" height="30"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="100" id="NlM-aU-hQ8"/>
+                                                <constraint firstAttribute="height" constant="30" id="S9g-b7-fcz"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3zL-Ns-jHU">
+                                            <rect key="frame" x="10" y="118.66666666666663" width="408" height="35"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="35" id="C8V-2h-flu"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="3zL-Ns-jHU" secondAttribute="bottom" constant="20" id="OMW-MQ-glQ"/>
+                                        <constraint firstAttribute="trailing" secondItem="3zL-Ns-jHU" secondAttribute="trailing" constant="10" id="dVd-c8-ne7"/>
+                                        <constraint firstItem="3zL-Ns-jHU" firstAttribute="top" secondItem="VMH-Ol-pV3" secondAttribute="bottom" constant="15" id="ds0-ZB-DAN"/>
+                                        <constraint firstItem="VMH-Ol-pV3" firstAttribute="centerX" secondItem="3zL-Ns-jHU" secondAttribute="centerX" id="f13-pk-D1T"/>
+                                        <constraint firstItem="VMH-Ol-pV3" firstAttribute="centerX" secondItem="xO1-aG-STK" secondAttribute="centerX" id="kvJ-YR-1xg"/>
+                                        <constraint firstItem="3zL-Ns-jHU" firstAttribute="leading" secondItem="xO1-aG-STK" secondAttribute="leading" constant="10" id="sQx-Qe-Giv"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sbW-re-Pb7" userLabel="confirmView">
+                                    <rect key="frame" x="0.0" y="173.66666666666663" width="428" height="116"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yjN-ps-h6L">
+                                            <rect key="frame" x="174" y="38" width="80" height="40"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="40" id="Eob-Qu-yrO"/>
+                                                <constraint firstAttribute="width" constant="80" id="HG7-iz-WPm"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                            <state key="normal" title="Button"/>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstItem="yjN-ps-h6L" firstAttribute="centerX" secondItem="sbW-re-Pb7" secondAttribute="centerX" id="981-TW-YOZ"/>
+                                        <constraint firstItem="yjN-ps-h6L" firstAttribute="centerY" secondItem="sbW-re-Pb7" secondAttribute="centerY" id="JkP-54-3i3"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="35" id="FGQ-dI-qFe"/>
+                                <constraint firstAttribute="trailing" secondItem="xO1-aG-STK" secondAttribute="trailing" id="0z6-lN-g9z"/>
+                                <constraint firstAttribute="bottom" secondItem="sbW-re-Pb7" secondAttribute="bottom" id="4zk-rv-cqq"/>
+                                <constraint firstItem="sbW-re-Pb7" firstAttribute="leading" secondItem="bln-An-VTS" secondAttribute="leading" id="DHd-Dj-1hf"/>
+                                <constraint firstItem="sbW-re-Pb7" firstAttribute="height" secondItem="bln-An-VTS" secondAttribute="height" multiplier="0.4" id="F3g-gb-ep0"/>
+                                <constraint firstItem="xO1-aG-STK" firstAttribute="leading" secondItem="bln-An-VTS" secondAttribute="leading" id="F5P-YF-skK"/>
+                                <constraint firstAttribute="bottom" secondItem="sbW-re-Pb7" secondAttribute="bottom" id="Kng-Xz-Gc7"/>
+                                <constraint firstItem="xO1-aG-STK" firstAttribute="centerX" secondItem="bln-An-VTS" secondAttribute="centerX" id="PuU-eZ-Ywu"/>
+                                <constraint firstItem="xO1-aG-STK" firstAttribute="top" secondItem="bln-An-VTS" secondAttribute="top" id="fxO-iN-cKe"/>
+                                <constraint firstAttribute="trailing" secondItem="sbW-re-Pb7" secondAttribute="trailing" id="rAY-Jl-FCZ"/>
+                                <constraint firstItem="xO1-aG-STK" firstAttribute="height" secondItem="bln-An-VTS" secondAttribute="height" multiplier="0.6" id="tZ7-iG-KfZ"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n1p-xU-Tu4">
-                            <rect key="frame" x="10" y="193.5" width="50" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="20" id="430-Oh-z7H"/>
-                                <constraint firstAttribute="width" constant="50" id="gSf-r2-MhH"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iP0-dF-uhj">
-                            <rect key="frame" x="70" y="191" width="295" height="35"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="35" id="7IV-ZK-512"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KNx-da-NJU">
-                            <rect key="frame" x="10" y="258.5" width="50" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="50" id="BWw-cm-JKR"/>
-                                <constraint firstAttribute="height" constant="20" id="eDJ-LU-FjP"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TP5-kC-Wi9">
-                            <rect key="frame" x="10" y="318.5" width="50" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="20" id="Z0e-s2-MLB"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="ZMr-qB-k6u"/>
-                                <constraint firstAttribute="width" constant="50" id="hf0-79-opr"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="ukn-R4-7qV"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5WHY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KcC-2B-Pjk">
-                            <rect key="frame" x="10" y="378.5" width="50" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Kdo-SG-FDq"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="TPK-3S-8WG"/>
-                                <constraint firstAttribute="height" constant="20" id="bwL-Cw-vF9"/>
-                                <constraint firstAttribute="width" constant="50" id="kKM-DN-VKa"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wv9-LX-lYH">
-                            <rect key="frame" x="70" y="251" width="295" height="35"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="35" id="6mc-EC-xEf"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MSb-mb-e5D">
-                            <rect key="frame" x="70" y="311" width="295" height="35"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="35" id="2Gl-Eu-kHT"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <textField opaque="NO" contentMode="scaleToFill" restorationIdentifier="mondai" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="問題" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bcM-Yv-x6h">
-                            <rect key="frame" x="10" y="61" width="355" height="30"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="30" id="wOW-sm-j3P"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" returnKeyType="done"/>
-                        </textField>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tda-xq-xZU">
-                            <rect key="frame" x="147.5" y="111" width="80" height="15"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="15" id="5lM-WH-85k"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="F2F-Ns-2Vr"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="a1h-9N-9rF"/>
-                                <constraint firstAttribute="width" constant="80" id="g7S-nX-bjm"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R7D-wv-oND">
-                            <rect key="frame" x="147.5" y="171" width="80" height="15"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="3BA-du-mcL"/>
-                                <constraint firstAttribute="height" constant="15" id="Ojh-t3-gsx"/>
-                                <constraint firstAttribute="width" constant="80" id="hJj-z0-IEs"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="qb2-cZ-yj0"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FAQ-RH-z3g">
-                            <rect key="frame" x="147.5" y="231" width="80" height="15"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="DHG-6U-RUd"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="QpZ-mx-pCw"/>
-                                <constraint firstAttribute="width" constant="80" id="bR1-hU-gir"/>
-                                <constraint firstAttribute="height" constant="15" id="mdF-gh-MNS"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="shS-Vz-FQn">
-                            <rect key="frame" x="147.5" y="291" width="80" height="15"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="15" id="YQY-7Z-23p"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="ePI-mD-10U"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="hMb-Z3-MMy"/>
-                                <constraint firstAttribute="width" constant="80" id="x2i-Rk-vor"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="それは何故か" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D4x-Fk-3lQ">
-                            <rect key="frame" x="147.5" y="351" width="80" height="15"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="15" id="5wZ-sB-VH2"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="J5O-iq-GC2"/>
-                                <constraint firstAttribute="width" constant="80" id="kGN-EN-M2b"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="lvh-yA-5rZ"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qPR-8W-VIN">
-                            <rect key="frame" x="70" y="371" width="295" height="35"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="35" id="Kjs-OR-eEF"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="6sc-BC-ng9">
-                            <rect key="frame" x="125" y="107" width="17" height="18"/>
-                        </imageView>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Leq-Ky-9aw">
-                            <rect key="frame" x="125" y="170" width="17" height="17"/>
-                        </imageView>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="h2T-LG-oA8">
-                            <rect key="frame" x="125" y="230" width="17" height="17"/>
-                        </imageView>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="IF7-Vp-cJ5">
-                            <rect key="frame" x="125" y="290" width="17" height="17"/>
-                        </imageView>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ROa-y4-98S">
-                            <rect key="frame" x="125" y="350" width="17" height="17"/>
-                        </imageView>
+                        </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" systemColor="systemIndigoColor"/>
                     <constraints>
-                        <constraint firstItem="BCF-qr-j9X" firstAttribute="leading" secondItem="n1p-xU-Tu4" secondAttribute="leading" id="7tY-xK-xV7"/>
-                        <constraint firstItem="tda-xq-xZU" firstAttribute="leading" secondItem="6sc-BC-ng9" secondAttribute="trailing" constant="5.5" id="9zh-kh-GRp"/>
-                        <constraint firstItem="IF7-Vp-cJ5" firstAttribute="leading" secondItem="h2T-LG-oA8" secondAttribute="leading" id="BAx-nA-60b"/>
-                        <constraint firstItem="BCF-qr-j9X" firstAttribute="leading" secondItem="KNx-da-NJU" secondAttribute="leading" id="Cib-XX-mMJ"/>
-                        <constraint firstItem="D4x-Fk-3lQ" firstAttribute="leading" secondItem="shS-Vz-FQn" secondAttribute="leading" id="CkG-rL-r0K"/>
-                        <constraint firstItem="IF7-Vp-cJ5" firstAttribute="centerY" secondItem="shS-Vz-FQn" secondAttribute="centerY" id="CsC-e1-IUn"/>
-                        <constraint firstItem="Leq-Ky-9aw" firstAttribute="leading" secondItem="6sc-BC-ng9" secondAttribute="leading" id="Deq-4u-gEh"/>
-                        <constraint firstItem="iP0-dF-uhj" firstAttribute="leading" secondItem="MSb-mb-e5D" secondAttribute="leading" id="DqT-gR-1km"/>
-                        <constraint firstItem="iP0-dF-uhj" firstAttribute="leading" secondItem="n1p-xU-Tu4" secondAttribute="trailing" constant="10" id="Edn-73-Z6b"/>
-                        <constraint firstItem="iP0-dF-uhj" firstAttribute="trailing" secondItem="bcM-Yv-x6h" secondAttribute="trailing" id="H9D-f1-jxh"/>
-                        <constraint firstItem="shS-Vz-FQn" firstAttribute="top" secondItem="Wv9-LX-lYH" secondAttribute="bottom" constant="5" id="HNB-wU-0CG"/>
-                        <constraint firstItem="iP0-dF-uhj" firstAttribute="top" secondItem="xjS-nl-j7W" secondAttribute="bottom" constant="25" id="Hz7-qw-KXr"/>
-                        <constraint firstItem="iP0-dF-uhj" firstAttribute="leading" secondItem="xjS-nl-j7W" secondAttribute="leading" id="I5c-qj-2bj"/>
-                        <constraint firstItem="KNx-da-NJU" firstAttribute="centerY" secondItem="1c2-cp-ylY" secondAttribute="centerY" id="IUZ-UT-wuk"/>
-                        <constraint firstItem="Wv9-LX-lYH" firstAttribute="trailing" secondItem="MSb-mb-e5D" secondAttribute="trailing" id="JT5-WN-tN1"/>
-                        <constraint firstItem="ROa-y4-98S" firstAttribute="centerY" secondItem="D4x-Fk-3lQ" secondAttribute="centerY" id="L4L-Ay-Kbu"/>
-                        <constraint firstItem="Leq-Ky-9aw" firstAttribute="top" secondItem="xjS-nl-j7W" secondAttribute="bottom" constant="3" id="O6H-kA-gLk"/>
-                        <constraint firstItem="qPR-8W-VIN" firstAttribute="leading" secondItem="KcC-2B-Pjk" secondAttribute="trailing" constant="10" id="OIM-bl-ztV"/>
-                        <constraint firstItem="MSb-mb-e5D" firstAttribute="leading" secondItem="TP5-kC-Wi9" secondAttribute="trailing" constant="10" id="Om5-50-hDh"/>
-                        <constraint firstItem="tda-xq-xZU" firstAttribute="top" secondItem="bcM-Yv-x6h" secondAttribute="bottom" constant="20" id="PHH-Q2-cm4"/>
-                        <constraint firstItem="D4x-Fk-3lQ" firstAttribute="leading" secondItem="R7D-wv-oND" secondAttribute="leading" id="QgW-9F-Ek4"/>
-                        <constraint firstItem="BCF-qr-j9X" firstAttribute="centerY" secondItem="xjS-nl-j7W" secondAttribute="centerY" id="S44-YL-XZA"/>
-                        <constraint firstItem="D4x-Fk-3lQ" firstAttribute="top" secondItem="MSb-mb-e5D" secondAttribute="bottom" constant="5" id="TZM-bC-vUi"/>
-                        <constraint firstItem="D4x-Fk-3lQ" firstAttribute="leading" secondItem="FAQ-RH-z3g" secondAttribute="leading" id="YqR-Z1-esf"/>
-                        <constraint firstItem="MSb-mb-e5D" firstAttribute="top" secondItem="Wv9-LX-lYH" secondAttribute="bottom" constant="25" id="Zsf-0G-bSi"/>
-                        <constraint firstAttribute="trailing" secondItem="bcM-Yv-x6h" secondAttribute="trailing" constant="10" id="bxF-U5-s8h"/>
-                        <constraint firstItem="h2T-LG-oA8" firstAttribute="leading" secondItem="Leq-Ky-9aw" secondAttribute="leading" id="eKi-qo-jUL"/>
-                        <constraint firstItem="D4x-Fk-3lQ" firstAttribute="centerX" secondItem="tda-xq-xZU" secondAttribute="centerX" id="eRL-6I-eBh"/>
-                        <constraint firstItem="Leq-Ky-9aw" firstAttribute="centerY" secondItem="R7D-wv-oND" secondAttribute="centerY" id="eg8-5a-ySu"/>
-                        <constraint firstAttribute="trailing" secondItem="MSb-mb-e5D" secondAttribute="trailing" constant="10" id="etf-Fg-CL7"/>
-                        <constraint firstItem="ROa-y4-98S" firstAttribute="top" secondItem="MSb-mb-e5D" secondAttribute="bottom" constant="3" id="f8a-Uu-sP8"/>
-                        <constraint firstAttribute="trailing" secondItem="qPR-8W-VIN" secondAttribute="trailing" constant="10" id="fYA-Jh-U2g"/>
-                        <constraint firstItem="xjS-nl-j7W" firstAttribute="leading" secondItem="1c2-cp-ylY" secondAttribute="leading" constant="70" id="jhM-bo-ifS"/>
-                        <constraint firstItem="xjS-nl-j7W" firstAttribute="top" secondItem="tda-xq-xZU" secondAttribute="bottom" constant="5" id="lBZ-uH-5fC"/>
-                        <constraint firstItem="Wv9-LX-lYH" firstAttribute="top" secondItem="iP0-dF-uhj" secondAttribute="bottom" constant="25" id="lCV-Ws-orn"/>
-                        <constraint firstAttribute="trailing" secondItem="xjS-nl-j7W" secondAttribute="trailing" constant="10" id="lHe-uL-xKV"/>
-                        <constraint firstItem="6sc-BC-ng9" firstAttribute="top" secondItem="bcM-Yv-x6h" secondAttribute="bottom" constant="15" id="mEH-qm-USk"/>
-                        <constraint firstItem="qPR-8W-VIN" firstAttribute="top" secondItem="MSb-mb-e5D" secondAttribute="bottom" constant="25" id="mYM-pC-PpR"/>
-                        <constraint firstItem="R7D-wv-oND" firstAttribute="top" secondItem="xjS-nl-j7W" secondAttribute="bottom" constant="5" id="nH6-TL-J21"/>
-                        <constraint firstItem="ROa-y4-98S" firstAttribute="leading" secondItem="IF7-Vp-cJ5" secondAttribute="leading" id="oN4-qj-OWs"/>
-                        <constraint firstItem="KNx-da-NJU" firstAttribute="top" secondItem="n1p-xU-Tu4" secondAttribute="bottom" constant="45" id="oVx-qt-2hP"/>
-                        <constraint firstItem="KcC-2B-Pjk" firstAttribute="top" secondItem="TP5-kC-Wi9" secondAttribute="bottom" constant="40" id="pFA-pi-npu"/>
-                        <constraint firstItem="Wv9-LX-lYH" firstAttribute="centerY" secondItem="1c2-cp-ylY" secondAttribute="centerY" id="rop-k7-nFI"/>
-                        <constraint firstItem="h2T-LG-oA8" firstAttribute="top" secondItem="iP0-dF-uhj" secondAttribute="bottom" constant="3" id="sCj-cW-srZ"/>
-                        <constraint firstItem="IF7-Vp-cJ5" firstAttribute="top" secondItem="Wv9-LX-lYH" secondAttribute="bottom" constant="3" id="u4Z-lr-P2N"/>
-                        <constraint firstItem="h2T-LG-oA8" firstAttribute="centerY" secondItem="FAQ-RH-z3g" secondAttribute="centerY" id="urk-MG-Vh0"/>
-                        <constraint firstItem="FAQ-RH-z3g" firstAttribute="top" secondItem="iP0-dF-uhj" secondAttribute="bottom" constant="5" id="waM-06-mL9"/>
-                        <constraint firstItem="KcC-2B-Pjk" firstAttribute="leading" secondItem="1c2-cp-ylY" secondAttribute="leading" constant="10" id="xJS-gm-kyH"/>
-                        <constraint firstItem="Wv9-LX-lYH" firstAttribute="leading" secondItem="MSb-mb-e5D" secondAttribute="leading" id="yZc-5c-2S4"/>
-                        <constraint firstItem="TP5-kC-Wi9" firstAttribute="top" secondItem="KNx-da-NJU" secondAttribute="bottom" constant="40" id="z0e-lV-zQ1"/>
-                        <constraint firstItem="bcM-Yv-x6h" firstAttribute="leading" secondItem="1c2-cp-ylY" secondAttribute="leading" constant="10" id="zGF-vf-PaC"/>
-                        <constraint firstItem="tda-xq-xZU" firstAttribute="centerX" secondItem="1c2-cp-ylY" secondAttribute="centerX" id="zpf-Ad-X3E"/>
+                        <constraint firstItem="bln-An-VTS" firstAttribute="height" secondItem="dt4-m7-yZD" secondAttribute="height" multiplier="0.35" id="33q-fM-eUx"/>
+                        <constraint firstItem="1fy-10-fnT" firstAttribute="top" secondItem="dt4-m7-yZD" secondAttribute="top" id="6DA-kR-Q8i"/>
+                        <constraint firstItem="bln-An-VTS" firstAttribute="leading" secondItem="dt4-m7-yZD" secondAttribute="leading" id="BYW-RE-Abl"/>
+                        <constraint firstItem="1fy-10-fnT" firstAttribute="leading" secondItem="dt4-m7-yZD" secondAttribute="leading" id="Chz-db-Q0C"/>
+                        <constraint firstAttribute="trailing" secondItem="bln-An-VTS" secondAttribute="trailing" id="D3e-Nb-IDa"/>
+                        <constraint firstAttribute="bottom" secondItem="bln-An-VTS" secondAttribute="bottom" id="FtQ-EG-43h"/>
+                        <constraint firstItem="1fy-10-fnT" firstAttribute="height" secondItem="dt4-m7-yZD" secondAttribute="height" multiplier="0.65" id="KQa-w7-o3C"/>
+                        <constraint firstAttribute="trailing" secondItem="1fy-10-fnT" secondAttribute="trailing" id="gq5-4d-bfi"/>
+                        <constraint firstAttribute="trailing" secondItem="bln-An-VTS" secondAttribute="trailing" id="o4H-h0-6KH"/>
+                        <constraint firstAttribute="trailing" secondItem="bln-An-VTS" secondAttribute="trailing" id="pqB-WH-B13"/>
+                        <constraint firstItem="bln-An-VTS" firstAttribute="leading" secondItem="dt4-m7-yZD" secondAttribute="leading" id="rVH-rZ-7Gi"/>
+                        <constraint firstItem="bln-An-VTS" firstAttribute="leading" secondItem="dt4-m7-yZD" secondAttribute="leading" id="yJ3-uJ-6rH"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DRW-HS-EZ8">
-                    <rect key="frame" x="162.5" y="547" width="50" height="25"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="50" id="WVX-8X-mUL"/>
-                        <constraint firstAttribute="height" constant="25" id="yyW-Xg-rug"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QVx-vJ-nZy">
-                    <rect key="frame" x="10" y="577" width="355" height="35"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="35" id="cLs-fc-pyH"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <textInputTraits key="textInputTraits"/>
-                </textField>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qKh-Ka-X1s">
-                    <rect key="frame" x="137.5" y="627" width="100" height="30"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="30" id="0fH-Hv-5sR"/>
-                        <constraint firstAttribute="width" constant="100" id="sp7-q3-xgC"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                    <state key="normal" title="Button"/>
-                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="1c2-cp-ylY" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" identifier="ViewTop" id="2hR-8S-gH0"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="QVx-vJ-nZy" secondAttribute="trailing" constant="10" id="3QV-J7-ets"/>
-                <constraint firstItem="1c2-cp-ylY" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" identifier="ViewRight" id="EQz-FN-B6g"/>
-                <constraint firstItem="QVx-vJ-nZy" firstAttribute="top" secondItem="DRW-HS-EZ8" secondAttribute="bottom" constant="5" id="VFo-Kb-zai"/>
-                <constraint firstItem="QVx-vJ-nZy" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="10" id="Xe8-yd-det"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1c2-cp-ylY" secondAttribute="bottom" constant="130" id="YMM-Ea-Wzm"/>
-                <constraint firstItem="DRW-HS-EZ8" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="ZQI-2f-VII"/>
-                <constraint firstItem="qKh-Ka-X1s" firstAttribute="top" secondItem="QVx-vJ-nZy" secondAttribute="bottom" constant="15" id="ZqD-OL-mpI"/>
-                <constraint firstItem="1c2-cp-ylY" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" identifier="ViewLeft" id="adJ-vw-Ggg"/>
-                <constraint firstAttribute="trailing" secondItem="1c2-cp-ylY" secondAttribute="trailing" id="iGj-WI-hg7"/>
-                <constraint firstItem="DRW-HS-EZ8" firstAttribute="top" secondItem="1c2-cp-ylY" secondAttribute="bottom" constant="10" id="tAe-q6-BpP"/>
-                <constraint firstItem="qKh-Ka-X1s" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="wU4-Bn-nj1"/>
+                <constraint firstItem="dt4-m7-yZD" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="SE6-Hm-2HO"/>
+                <constraint firstItem="dt4-m7-yZD" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Zkx-K4-wLw"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="dt4-m7-yZD" secondAttribute="bottom" constant="20" id="o3L-Wn-QdY"/>
+                <constraint firstItem="dt4-m7-yZD" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="s27-HA-W70"/>
             </constraints>
             <connections>
-                <outlet property="analysisView" destination="1c2-cp-ylY" id="clh-OU-dah"/>
-                <outlet property="confirmButton" destination="qKh-Ka-X1s" id="u4g-2E-4H3"/>
-                <outlet property="fiveArrow" destination="ROa-y4-98S" id="QPg-I7-8RH"/>
-                <outlet property="fiveWHYLabel" destination="KcC-2B-Pjk" id="rki-qu-CEL"/>
-                <outlet property="fiveWhyTextField" destination="qPR-8W-VIN" id="eqJ-Vf-40Y"/>
-                <outlet property="fourArrow" destination="IF7-Vp-cJ5" id="XvB-4s-Knw"/>
-                <outlet property="fourWHYLabel" destination="TP5-kC-Wi9" id="FmM-YO-o1O"/>
-                <outlet property="fourWhyTextField" destination="MSb-mb-e5D" id="8Nm-Gm-z2F"/>
-                <outlet property="measuresLabel" destination="DRW-HS-EZ8" id="hmk-4M-lAI"/>
-                <outlet property="measuresTextField" destination="QVx-vJ-nZy" id="40U-Is-EOs"/>
-                <outlet property="oneArrow" destination="6sc-BC-ng9" id="njR-7D-tLA"/>
-                <outlet property="oneWHYLabel" destination="BCF-qr-j9X" id="GRh-jA-OvT"/>
-                <outlet property="oneWhyTextFiled" destination="xjS-nl-j7W" id="LLw-rS-dHb"/>
-                <outlet property="problemTextField" destination="bcM-Yv-x6h" id="tnq-uc-H2j"/>
-                <outlet property="threeArrow" destination="h2T-LG-oA8" id="Lyi-cG-UjO"/>
-                <outlet property="threeWHYLabel" destination="KNx-da-NJU" id="M49-SW-QhH"/>
-                <outlet property="threeWhyTextField" destination="Wv9-LX-lYH" id="lvX-Po-ySp"/>
-                <outlet property="twoArrow" destination="Leq-Ky-9aw" id="cMB-XT-2fV"/>
-                <outlet property="twoWHYLabel" destination="n1p-xU-Tu4" id="Ypo-r2-gqG"/>
-                <outlet property="twoWhyTextField" destination="iP0-dF-uhj" id="hnT-EP-SI0"/>
+                <outlet property="confirmButton" destination="yjN-ps-h6L" id="Q58-wI-DWL"/>
+                <outlet property="fiveAnalysisView" destination="vz6-6V-icK" id="phy-8P-SqL"/>
+                <outlet property="fiveArrow" destination="2fX-X4-W2g" id="aP0-lL-31F"/>
+                <outlet property="fiveWHYLabel" destination="XF8-4D-BTK" id="cHF-nC-xxN"/>
+                <outlet property="fiveWhyTextField" destination="O91-kj-jIv" id="8JI-ur-asA"/>
+                <outlet property="fourAnalysisView" destination="vfs-sW-BFV" id="oUf-0h-RRW"/>
+                <outlet property="fourArrow" destination="AvI-8g-uwR" id="7cf-Oh-Dji"/>
+                <outlet property="fourWHYLabel" destination="hve-z1-9Zj" id="pOX-TS-HUH"/>
+                <outlet property="fourWhyTextField" destination="8vt-43-NNq" id="DFu-D3-LaU"/>
+                <outlet property="measuresLabel" destination="VMH-Ol-pV3" id="hxA-aE-Vyl"/>
+                <outlet property="measuresTextField" destination="3zL-Ns-jHU" id="ABg-18-Jo8"/>
+                <outlet property="oneAnalysisView" destination="NQw-Bi-NAF" id="X6f-Ak-uRF"/>
+                <outlet property="oneArrow" destination="2G9-Sa-Qgp" id="DKg-fs-cZX"/>
+                <outlet property="oneWHYLabel" destination="OOK-J0-VcV" id="djg-0d-Izi"/>
+                <outlet property="oneWhyTextFiled" destination="tMG-Af-eBB" id="mie-eY-ITL"/>
+                <outlet property="problemTextField" destination="glL-J5-IDO" id="wty-ek-pDq"/>
+                <outlet property="problemView" destination="NqV-K0-N6Z" id="mDl-eQ-iu4"/>
+                <outlet property="threeAnalysisView" destination="aEZ-hG-eOG" id="2fy-yl-v0O"/>
+                <outlet property="threeArrow" destination="EfZ-a8-g4J" id="a3J-PY-kH0"/>
+                <outlet property="threeWHYLabel" destination="j1o-gJ-ui8" id="fTc-Jv-5Mh"/>
+                <outlet property="threeWhyTextField" destination="8vt-43-NNq" id="CkH-3D-u8g"/>
+                <outlet property="twoAnalysisView" destination="wDl-p0-BhU" id="bgo-wf-qqA"/>
+                <outlet property="twoArrow" destination="cvv-Ge-kzy" id="Hft-YP-e8x"/>
+                <outlet property="twoWHYLabel" destination="aCt-mf-JsX" id="tXm-hc-f1q"/>
+                <outlet property="twoWhyTextField" destination="xPN-h8-8Xr" id="pEF-2L-7TX"/>
             </connections>
-            <point key="canvasLocation" x="136.80000000000001" y="82.3088455772114"/>
+            <point key="canvasLocation" x="133.59999999999999" y="80.50974512743629"/>
         </view>
     </objects>
     <resources>
         <image name="arrow.down" catalog="system" width="120" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemIndigoColor">
+            <color red="0.34509803921568627" green="0.33725490196078434" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPurpleColor">
+            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/whywhyanalysisApp/Src/View/ShowAnalysisListCustumCell.swift
+++ b/whywhyanalysisApp/Src/View/ShowAnalysisListCustumCell.swift
@@ -13,6 +13,7 @@ internal class ShowAnalysisListCustumCell: UITableViewCell {
     @IBOutlet internal weak var measuresLabel: UILabel!
     @IBOutlet internal weak var problemLabel: UILabel!
     @IBOutlet internal weak var statusButton: UIButton!
+    @IBOutlet internal weak var problemLabelUnderline: UIView!
 
     override internal func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
@@ -22,6 +23,9 @@ internal class ShowAnalysisListCustumCell: UITableViewCell {
         super.awakeFromNib()
         // レイアウト設定
         statusButton.backgroundColor = AppColor.btnBgColor
+        measuresLabel.layer.borderWidth = 0.7
+        measuresLabel.layer.borderColor = AppColor.mainColor.cgColor
+        problemLabelUnderline.backgroundColor = AppColor.mainColor
         statusButton.setTitleColor(.white, for: .normal)
     }
 }

--- a/whywhyanalysisApp/Src/View/ShowAnalysisListCustumCell.xib
+++ b/whywhyanalysisApp/Src/View/ShowAnalysisListCustumCell.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,57 +15,90 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="問題ラベル" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2NN-sQ-tG0" customClass="anaysisListCustomCell" customModule="whywhyanalysisApp" customModuleProvider="target">
-                    <rect key="frame" x="10" y="60" width="300" height="20"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="20" id="R20-0H-6K7"/>
-                        <constraint firstAttribute="width" constant="300" id="RKe-sa-nTW"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="対策ラベル" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yc4-at-u87">
-                    <rect key="frame" x="10" y="32" width="300" height="20"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yc4-at-u87">
+                    <rect key="frame" x="10" y="94" width="300" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="300" id="Dz7-St-tM1"/>
-                        <constraint firstAttribute="height" constant="20" id="fjy-co-bFr"/>
+                        <constraint firstAttribute="height" constant="30" id="YmE-hO-tAs"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
+                    <attributedString key="attributedText">
+                        <fragment content="対策ラベル">
+                            <attributes>
+                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                <font key="NSFont" size="17" name=".HiraKakuInterface-W3"/>
+                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" firstLineHeadIndent="4" tighteningFactorForTruncation="0.0"/>
+                            </attributes>
+                        </fragment>
+                    </attributedString>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zoQ-yX-hr8">
-                    <rect key="frame" x="170" y="10" width="100" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zoQ-yX-hr8">
+                    <rect key="frame" x="210" y="54" width="60" height="30"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="100" id="bSk-M2-Nx9"/>
-                        <constraint firstAttribute="height" constant="30" id="u7S-WA-mY7"/>
+                        <constraint firstAttribute="width" constant="60" id="3QV-ND-HTE"/>
+                        <constraint firstAttribute="height" constant="30" id="CrS-Q3-dee"/>
                     </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="ステータスボタン"/>
                     <connections>
                         <action selector="changeStatusButton:" destination="-1" eventType="touchUpInside" id="I3m-vI-iGi"/>
                     </connections>
                 </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dTv-4E-ATx" userLabel="Problem Label">
+                    <rect key="frame" x="10" y="134" width="300" height="16.666666666666657"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="300" id="Ppr-8o-iNg"/>
+                    </constraints>
+                    <attributedString key="attributedText">
+                        <fragment content="問題ラベル">
+                            <attributes>
+                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                <font key="NSFont" size="15" name=".HiraKakuInterface-W3"/>
+                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                            </attributes>
+                        </fragment>
+                    </attributedString>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4e-bf-3gP" userLabel="problemLabelUnderline">
+                    <rect key="frame" x="10" y="151.33333333333334" width="300" height="0.66666666666665719"/>
+                    <color key="backgroundColor" systemColor="systemBlueColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="0.69999999999999996" id="1G7-WP-oLg"/>
+                    </constraints>
+                </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="Yc4-at-u87" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="32" id="CAA-mg-6SB"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="zoQ-yX-hr8" secondAttribute="trailing" constant="50" id="D7q-0x-Tix"/>
+                <constraint firstItem="dTv-4E-ATx" firstAttribute="top" secondItem="Yc4-at-u87" secondAttribute="bottom" constant="10" id="BQh-99-FdK"/>
+                <constraint firstItem="dTv-4E-ATx" firstAttribute="leading" secondItem="Yc4-at-u87" secondAttribute="leading" id="Fkq-3q-g5L"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="g4e-bf-3gP" secondAttribute="trailing" constant="10" id="HMY-7E-390"/>
                 <constraint firstItem="zoQ-yX-hr8" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="10" id="JbR-UA-Tst"/>
+                <constraint firstItem="g4e-bf-3gP" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="NmB-NF-dzv"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Yc4-at-u87" secondAttribute="trailing" constant="10" id="RYb-0w-FZ9"/>
-                <constraint firstItem="2NN-sQ-tG0" firstAttribute="top" secondItem="Yc4-at-u87" secondAttribute="bottom" constant="8" id="bjO-l3-qVk"/>
-                <constraint firstItem="2NN-sQ-tG0" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="ciQ-5d-ooZ"/>
+                <constraint firstItem="Yc4-at-u87" firstAttribute="top" secondItem="zoQ-yX-hr8" secondAttribute="bottom" constant="10" id="Rnj-wy-SgB"/>
+                <constraint firstItem="g4e-bf-3gP" firstAttribute="top" secondItem="dTv-4E-ATx" secondAttribute="bottom" constant="0.5" id="Wbj-DD-rhA"/>
                 <constraint firstItem="Yc4-at-u87" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="hbF-iY-Xx6"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="zoQ-yX-hr8" secondAttribute="trailing" constant="50" id="vGJ-Vv-THi"/>
                 <constraint firstItem="Yc4-at-u87" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="wBv-7P-YEq"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <connections>
                 <outlet property="measuresLabel" destination="Yc4-at-u87" id="WJq-kK-RBS"/>
-                <outlet property="problemLabel" destination="2NN-sQ-tG0" id="EIO-0o-LUO"/>
+                <outlet property="problemLabel" destination="dTv-4E-ATx" id="LIe-Qx-yU4"/>
+                <outlet property="problemLabelUnderline" destination="g4e-bf-3gP" id="Ful-r6-vLS"/>
                 <outlet property="statusButton" destination="zoQ-yX-hr8" id="cdc-fe-813"/>
             </connections>
-            <point key="canvasLocation" x="-258.75" y="66.549295774647888"/>
+            <point key="canvasLocation" x="-259.34579439252337" y="66.090712742980571"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
## 実装内容概要
各画面のレイアウトを修正しました。

## 実装詳細
下記画面について修正しました。
オブジェクトの配置変更（中央寄せなど。大幅な位置は修正していません)や下線追加などをしています。

　・分析一覧表示画面
　・分析編集画面
　・分析編集完了画面
　・ステータス変更画面

分析編集画面についてはUIViewを用いて親Viewと子Viewの比率を元にオブジェクトの配置をしています。

## レビュー時の注意点
実施可能なシミュレータのうち、画面最大サイズと最小サイズの下記２つの画面サイズでレイアウトを確認済みです。
実機テストに関してはstoryboardで選択可能な画面サイズでない為正常なレイアウト確認ができておりません。可能でしたら実機テストをお願いいたします。

以上、よろしくお願いいたします。
